### PR TITLE
Fixing typo within connectWifi command

### DIFF
--- a/esp8266Code.ino
+++ b/esp8266Code.ino
@@ -22,7 +22,7 @@ void setup()
   Serial.begin(9600);
   delay(10);
 
-  connectWiFi();
+  connectWifi();
   statusWifi();
 
   // Notify the MQTT broker when ESP8266 loses connection


### PR DESCRIPTION
Small typo in the connectWifi command